### PR TITLE
Fix set-cookie header

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -210,7 +210,9 @@ export class Auth {
 
 	private async handleSignout(event: RequestEvent): Promise<EndpointOutput> {
 		const headers = new Headers();
-		this.getDeleteCookieHeaders().forEach((v) => headers.append('set-cookie', v));
+		for (const cookie of this.getDeleteCookieHeaders()) {
+			headers.append('set-cookie', cookie);
+		}
 
 		if (event.request.method === 'POST') {
 			return {
@@ -247,9 +249,9 @@ export class Auth {
 
 		const headers = new Headers();
 		headers.append('Location', redirect);
-		this.getSetCookieHeaders(accessToken, refreshToken, expiresAt).forEach((v) =>
-			headers.append('set-cookie', v)
-		);
+		for (const cookie of this.getSetCookieHeaders(accessToken, refreshToken, expiresAt)) {
+			headers.append('set-cookie', cookie);
+		}
 
 		return {
 			status: 302,
@@ -295,9 +297,9 @@ export class Auth {
 			const expiresAt = getExpirationFromToken(newAccessToken);
 
 			const headers = new Headers();
-			this.getSetCookieHeaders(newAccessToken, newRefreshToken, expiresAt).forEach((v) =>
-				headers.append('set-cookie', v)
-			);
+			for (const cookie of this.getSetCookieHeaders(newAccessToken, newRefreshToken, expiresAt)) {
+				headers.append('set-cookie', cookie);
+			}
 
 			if (event.request.method === 'GET') {
 				const redirect = await this.getRedirectUrl(searchParams.get('redirect') ?? undefined);
@@ -315,7 +317,9 @@ export class Auth {
 		} catch (error) {
 			if (error instanceof RefreshTokenExpiredError) {
 				const headers = new Headers();
-				this.getDeleteCookieHeaders().forEach((v) => headers.append('set-cookie', v));
+				for (const cookie of this.getDeleteCookieHeaders()) {
+					headers.append('set-cookie', cookie);
+				}
 
 				if (event.request.method === 'GET') {
 					const redirect = await this.getRedirectUrl(searchParams.get('redirect') ?? undefined);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -209,11 +209,12 @@ export class Auth {
 	}
 
 	private async handleSignout(event: RequestEvent): Promise<EndpointOutput> {
+		const headers = new Headers();
+		this.getDeleteCookieHeaders().forEach((v) => headers.append('set-cookie', v));
+
 		if (event.request.method === 'POST') {
 			return {
-				headers: {
-					'set-cookie': this.getDeleteCookieHeaders()
-				},
+				headers,
 				body: {
 					signout: true
 				}
@@ -221,13 +222,10 @@ export class Auth {
 		}
 
 		const redirect = await this.getRedirectUrl(event.url.searchParams.get('redirect') ?? undefined);
-
+		headers.append('Location', redirect);
 		return {
 			status: 302,
-			headers: {
-				'set-cookie': this.getDeleteCookieHeaders(),
-				Location: redirect
-			}
+			headers
 		};
 	}
 
@@ -247,12 +245,15 @@ export class Auth {
 
 		const redirect = await this.getRedirectUrl(redirectUrl);
 
+		const headers = new Headers();
+		headers.append('Location', redirect);
+		this.getSetCookieHeaders(accessToken, refreshToken, expiresAt).forEach((v) =>
+			headers.append('set-cookie', v)
+		);
+
 		return {
 			status: 302,
-			headers: {
-				'set-cookie': this.getSetCookieHeaders(accessToken, refreshToken, expiresAt),
-				Location: redirect
-			}
+			headers
 		};
 	}
 
@@ -293,40 +294,40 @@ export class Auth {
 			const newRefreshToken = tokens.refresh_token;
 			const expiresAt = getExpirationFromToken(newAccessToken);
 
+			const headers = new Headers();
+			this.getSetCookieHeaders(newAccessToken, newRefreshToken, expiresAt).forEach((v) =>
+				headers.append('set-cookie', v)
+			);
+
 			if (event.request.method === 'GET') {
 				const redirect = await this.getRedirectUrl(searchParams.get('redirect') ?? undefined);
+				headers.append('Location', redirect);
 				return {
 					status: 302,
-					headers: {
-						'set-cookie': this.getSetCookieHeaders(newAccessToken, newRefreshToken, expiresAt),
-						Location: redirect
-					}
+					headers
 				};
 			} else {
 				return {
 					status: 200,
-					headers: {
-						'set-cookie': this.getSetCookieHeaders(newAccessToken, newRefreshToken, expiresAt)
-					}
+					headers
 				};
 			}
 		} catch (error) {
 			if (error instanceof RefreshTokenExpiredError) {
+				const headers = new Headers();
+				this.getDeleteCookieHeaders().forEach((v) => headers.append('set-cookie', v));
+
 				if (event.request.method === 'GET') {
 					const redirect = await this.getRedirectUrl(searchParams.get('redirect') ?? undefined);
+					headers.append('Location', redirect);
 					return {
 						status: 302,
-						headers: {
-							'set-cookie': this.getDeleteCookieHeaders(),
-							Location: redirect
-						}
+						headers
 					};
 				} else {
 					return {
 						status: 403,
-						headers: {
-							'set-cookie': this.getDeleteCookieHeaders()
-						}
+						headers
 					};
 				}
 			} else {


### PR DESCRIPTION
Using an array for the 'set-cookie' header does not seem to have the same behaviour on all platforms.
In CF Pages it will concatenate the array.
This should solve the problem